### PR TITLE
standard-output-names

### DIFF
--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -56,6 +56,11 @@ inputs:
     inputBinding:
       position: 6
       prefix: --memGB
+  run-id:
+    type: string?
+    inputBinding:
+      position: 7
+      prefix: --run-id
 
 outputs:
   somatic_cnv_vcf_gz:


### PR DESCRIPTION
- expose the setting of run-id to cwl level and set the default of run-id to be SM retrieved from RG of the tumor bam header.
- the output files are prefixed with PCAWG convention: <run-id>.<workflowName>.<dateString>