### PR TITLE
Feature/support new schema salad

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
 
 language: java
 jdk: 
-  - oraclejdk8
+  - oraclejdk9
 
 before_install:
   - pip2.7 install --user setuptools==24.0.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ before_install:
   - pip2.7 install --user setuptools==24.0.3
 
 install: 
-  - pip2.7 install --user cwl-runner cwltool==1.0.20160712154127 schema-salad==1.14.20160708181155 avro==1.8.1
+  - pip2.7 install --user cwl-runner cwltool==3.0.20200807132242
 
 script: 
 #- cwltool --non-strict Dockstore.cwl test.json 
   - mvn clean install 
+  - cwltool --validate Dockstore.cwl
 # unable to test tool execution, test data and runtime too large

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jdk:
   - oraclejdk9
 
 before_install:
+  - pyenv global 3.6.10
   - pip2.7 install --user setuptools==24.0.3
 
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ notifications:
 
 language: java
 jdk: 
-  - oraclejdk9
+  - openjdk12
 
 before_install:
+  - pyenv install --list
   - pyenv install 3.6.10
   - pyenv global 3.6.10
   - pip2.7 install --user setuptools==24.0.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jdk:
   - oraclejdk9
 
 before_install:
+  - pyenv install 3.6.10
   - pyenv global 3.6.10
   - pip2.7 install --user setuptools==24.0.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ before_install:
   - pyenv install --list
   - pyenv install 3.6.3
   - pyenv global 3.6.3
-  - pip2.7 install --user setuptools==24.0.3
+  - pip3 install --user setuptools==24.0.3
 
 install: 
-  - pip2.7 install --user cwl-runner cwltool==3.0.20200807132242
+  - pip3 install --user cwl-runner cwltool==3.0.20200807132242
 
 script: 
 #- cwltool --non-strict Dockstore.cwl test.json 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ jdk:
 
 before_install:
   - pyenv install --list
-  - pyenv install 3.6.10
-  - pyenv global 3.6.10
+  - pyenv install 3.6.3
+  - pyenv global 3.6.3
   - pip2.7 install --user setuptools==24.0.3
 
 install: 

--- a/Dockstore.cwl
+++ b/Dockstore.cwl
@@ -3,17 +3,20 @@
 class: CommandLineTool
 id: Seqware-Sanger-Somatic-Workflow
 label: Seqware-Sanger-Somatic-Workflow
+
+$namespaces:
+  foaf: http://xmlns.com/foaf/0.1/
+
 dct:creator:
   '@id': http://sanger.ac.uk/...
   foaf:name: Keiran Raine
   foaf:mbox: mailto:keiranmraine@gmail.com
-dct:contributor:
-  foaf:name: Brian O'Connor
-  foaf:mbox: mailto:broconno@ucsc.edu
 
 dct:contributor:
-  foaf:name: Denis Yuen
-  foaf:mbox: mailto:denis.yuen@oicr.on.ca
+  - foaf:name: Brian O'Connor
+    foaf:mbox: mailto:broconno@ucsc.edu
+  - foaf:name: Denis Yuen
+    foaf:mbox: mailto:denis.yuen@oicr.on.ca
 
 requirements:
 - class: DockerRequirement

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>7</source>
+          <target>7</target>
           <showDeprecation>true</showDeprecation>
         </configuration>
       </plugin>


### PR DESCRIPTION
Upgrading cwltool by default installs a newer version of schema salad which prevents duplicate keys. 

```
(venv) gluu@potato:~/CGP-Somatic-Docker$ cwltool --validate Dockstore.cwl
INFO /home/gluu/venv/bin/cwltool 3.0.20200807132242
INFO Resolved 'Dockstore.cwl' to 'file:///home/gluu/CGP-Somatic-Docker/Dockstore.cwl'
ERROR I'm sorry, I couldn't load this CWL file, try again with --debug for more information.
The error was: while constructing a mapping
  in "file:///home/gluu/CGP-Somatic-Docker/Dockstore.cwl", line 3, column 1
found duplicate key "dct:contributor" with value "ordereddict([('foaf:name', 'Denis Yuen'), ('foaf:mbox', 'mailto:denis.yuen@oicr.on.ca')])" (original value: "ordereddict([('foaf:name', "Brian O'Connor"), ('foaf:mbox', 'mailto:broconno@ucsc.edu')])")
  in "file:///home/gluu/CGP-Somatic-Docker/Dockstore.cwl", line 14, column 1

To suppress this check see:
    http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys

Duplicate keys will become an error in future releases, and are errors
by default when using the new API.
```

This fixes the duplicate key.

Also removed the warning:

```
URI prefix 'foaf' of 'foaf:name' not recognized, are you missing a $namespaces section?
URI prefix 'foaf' of 'foaf:mbox' not recognized, are you missing a $namespaces section?
URI prefix 'foaf' of 'foaf:name' not recognized, are you missing a $namespaces section?
URI prefix 'foaf' of 'foaf:mbox' not recognized, are you missing a $namespaces section?
URI prefix 'foaf' of 'foaf:name' not recognized, are you missing a $namespaces section?
URI prefix 'foaf' of 'foaf:mbox' not recognized, are you missing a $namespaces section?
```

Also update Travis to validate